### PR TITLE
refactor(tests): split algebra tests and fix cubic rounding bug

### DIFF
--- a/simple_equ/algebra/algebra.py
+++ b/simple_equ/algebra/algebra.py
@@ -159,8 +159,15 @@ def basic_qubic(a: int | float, b: int | float, c: int | float, d: int | float):
         roots.extend([x1, x2, x3])
 
     # It just removes the artifacts from floating point innacuracies here
-    roots = [round(x, 10) for x in roots]
-    return roots
+    rounded_roots = []
+    for x in roots:
+        real_part = round(x.real, 10) if isinstance(x, complex) else round(x, 10)
+        imag_part = round(x.imag, 10) if isinstance(x, complex) else 0
+        if imag_part == 0:
+            rounded_roots.append(float(real_part))
+        else:
+            rounded_roots.append(complex(real_part, imag_part))
+    return rounded_roots
 
 
 def basic_linear(a: int | float, b: int | float):

--- a/tests/algebra/test_algebra_real.py
+++ b/tests/algebra/test_algebra_real.py
@@ -21,6 +21,11 @@ from simple_equ import algebra
     ],
 )
 def test_power(base, exponent, expected):
+    """[Summary]: Verify that power returns the base raised to the exponent.
+
+    [Description]: Covers common cases including negative bases, negative
+    exponents, and zero values to ensure robustness in standard scenarios.
+    """
     assert algebra.power(base, exponent) == pytest.approx(expected, rel=1e-9)
 
 
@@ -34,14 +39,17 @@ def test_power(base, exponent, expected):
     ],
 )
 def test_factorial_positive(number, expected):
+    """[Summary]: Verify that factorial returns the correct value for positive integers."""
     assert algebra.factorial(number) == expected
 
 
 def test_factorial_negative():
+    """[Summary]: Verify that factorial handles negative integers by returning 1."""
     assert algebra.factorial(-5) == 1
 
 
 def test_factorial_float():
+    """[Summary]: Verify that factorial correctly handles floating-point inputs."""
     assert algebra.factorial(3.0) == 6
 
 
@@ -57,6 +65,7 @@ def test_factorial_float():
     ],
 )
 def test_gcd(a, b, expected):
+    """[Summary]: Verify that gcd returns the greatest common divisor."""
     assert algebra.gcd(a, b) == expected
 
 
@@ -70,10 +79,12 @@ def test_gcd(a, b, expected):
     ],
 )
 def test_sqrt_positive(number, expected):
+    """[Summary]: Verify that sqrt returns the square root for non-negative numbers."""
     assert algebra.sqrt(number) == expected
 
 
 def test_sqrt_negative():
+    """[Summary]: Verify that sqrt raises ValueError for negative inputs."""
     with pytest.raises(ValueError, match="Not a real number"):
         algebra.sqrt(-1)
 
@@ -89,6 +100,7 @@ def test_sqrt_negative():
     ],
 )
 def test_cbrt(x, expected):
+    """[Summary]: Verify that cbrt returns the real cube root."""
     assert algebra.cbrt(x) == pytest.approx(expected, rel=1e-9)
 
 
@@ -101,25 +113,15 @@ def test_cbrt(x, expected):
     ],
 )
 def test_basic_quadratic(a, b, c, expected):
+    """[Summary]: Verify that basic_quadratic returns real roots for common inputs."""
     root1, root2 = algebra.basic_quadratic(a, b, c)
     assert sorted([root1, root2]) == sorted(expected)
 
 
 def test_basic_quadratic_zero_a():
+    """[Summary]: Verify that basic_quadratic raises ZeroDivisionError when a is zero."""
     with pytest.raises(ZeroDivisionError):
         algebra.basic_quadratic(0, 1, 1)
-
-
-@pytest.mark.parametrize(
-    "a,b,c,d,expected",
-    [
-        (1, -6, 11, -6, [1, 2, 3]),
-    ],
-)
-def test_basic_qubic_three_real(a, b, c, d, expected):
-    roots = algebra.basic_qubic(a, b, c, d)
-    real_roots = sorted([r for r in roots if isinstance(r, (int, float))])
-    assert real_roots == pytest.approx(expected, rel=1e-9)
 
 
 @pytest.mark.parametrize(
@@ -131,10 +133,12 @@ def test_basic_qubic_three_real(a, b, c, d, expected):
     ],
 )
 def test_basic_linear(a, b, expected):
+    """[Summary]: Verify that basic_linear returns the correct solution."""
     assert algebra.basic_linear(a, b) == expected
 
 
 def test_basic_linear_zero_a():
+    """[Summary]: Verify that basic_linear raises ZeroDivisionError when a is zero."""
     with pytest.raises(ZeroDivisionError):
         algebra.basic_linear(0, 1)
 
@@ -151,9 +155,11 @@ def test_basic_linear_zero_a():
     ],
 )
 def test_is_divisible(a, b, expected):
+    """[Summary]: Verify that is_divisible correctly identifies divisibility."""
     assert algebra.is_divisible(a, b) == expected
 
 
 def test_is_divisible_zero_divisor():
+    """[Summary]: Verify that is_divisible raises ValueError when the divisor is zero."""
     with pytest.raises(ValueError, match="Cannot divide by zero"):
         algebra.is_divisible(10, 0)

--- a/tests/algebra/test_cmath.py
+++ b/tests/algebra/test_cmath.py
@@ -1,0 +1,119 @@
+import pytest
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+from simple_equ import algebra
+
+
+# ==============================================================================
+# tests for simple_equ.algebra.cmath module
+# ==============================================================================
+
+@pytest.mark.parametrize(
+    "real,imag,expected",
+    [
+        (3, 4, (3, 4)),
+        (1.5, -2, (1.5, -2)),
+        (0, 0, (0, 0)),
+    ],
+)
+def test_complex_num(real, imag, expected):
+    """[Summary]: Verify that complex_num creates a complex tuple."""
+    assert algebra.complex_num(real, imag) == expected
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        ((1, 2), (3, 4), (4, 6)),
+        ((1.5, -0.5), (0.5, 2.5), (2.0, 2.0)),
+    ],
+)
+def test_add(a, b, expected):
+    """[Summary]: Verify that add correctly sums two complex tuples."""
+    assert algebra.add(a, b) == expected
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        ((5, 7), (2, 3), (3, 4)),
+        ((1, 1), (1, 1), (0, 0)),
+    ],
+)
+def test_sub(a, b, expected):
+    """[Summary]: Verify that sub correctly subtracts two complex tuples."""
+    assert algebra.sub(a, b) == expected
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        ((1, 2), (3, 4), (-5, 10)),
+        ((1, 1), (1, -1), (2, 0)),
+    ],
+)
+def test_mul(a, b, expected):
+    """[Summary]: Verify that mul correctly multiplies two complex tuples."""
+    assert algebra.mul(a, b) == expected
+
+
+@pytest.mark.parametrize(
+    "a,expected",
+    [
+        ((3, 4), 5.0),
+        ((0, 0), 0.0),
+        ((1, 0), 1.0),
+        ((0, 1), 1.0),
+    ],
+)
+def test_magnitude(a, expected):
+    """[Summary]: Verify that magnitude returns the Euclidean norm of a complex tuple."""
+    assert algebra.magnitude(a) == pytest.approx(expected, rel=1e-9)
+
+
+# ==============================================================================
+# tests for cubic equations (basic_qubic from algebra module)
+# ==============================================================================
+
+@pytest.mark.parametrize(
+    "a,b,c,d,expected",
+    [
+        (1, -6, 11, -6, [1.0, 2.0, 3.0]),
+        (1, 0, 0, 0, [0.0, 0.0, 0.0]),
+    ],
+)
+def test_basic_qubic_real(a, b, c, d, expected):
+    """[Summary]: Verify that basic_qubic returns correct real roots."""
+    roots = algebra.basic_qubic(a, b, c, d)
+    # Extract real roots for comparison
+    real_roots = sorted([r for r in roots if isinstance(r, (int, float))])
+    assert real_roots == pytest.approx(expected, rel=1e-9)
+
+
+def test_basic_qubic_complex():
+    """[Summary]: Verify that basic_qubic returns complex roots when delta >= 0.
+
+    [Description]: Tests an equation with one real and two complex roots.
+    Equation: x^3 - 1 = 0 => roots: 1, -0.5 + 0.866j, -0.5 - 0.866j
+    """
+    roots = algebra.basic_qubic(1, 0, 0, -1)
+    
+    # Sort roots: real first, then complex by imaginary part
+    def root_sort_key(r):
+        if isinstance(r, (int, float)):
+            return (0, r, 0)
+        return (1, r.real, r.imag)
+        
+    sorted_roots = sorted(roots, key=root_sort_key)
+    
+    # 1 is the real root
+    # -0.5 +/- sqrt(3)/2 j are complex roots
+    assert sorted_roots[0] == pytest.approx(1.0, rel=1e-9)
+    assert sorted_roots[1].real == pytest.approx(-0.5, rel=1e-9)
+    assert abs(sorted_roots[1].imag) == pytest.approx(0.86602540378, rel=1e-9)
+    assert sorted_roots[2].real == pytest.approx(-0.5, rel=1e-9)
+    assert abs(sorted_roots[2].imag) == pytest.approx(0.86602540378, rel=1e-9)
+    assert sorted_roots[1].imag == -sorted_roots[2].imag


### PR DESCRIPTION
This PR refactors the algebra testing suite to improve organization and adhere to the project's new standard of separating real-number logic from complex number operations. It also resolves a bug discovered in the cubic equation solver.

Closes #96

Changes
1. Test Suite Refactoring
tests/algebra/test_algebra_real.py: Created to house all tests for real-numbered algebraic functions such as power, factorial, gcd, and linear/quadratic solvers.
tests/algebra/test_cmath.py: Created as a dedicated home for complex number arithmetic and cubic equation tests.
Cleanup: Removed the consolidated test_algebra.py which had become a "catch-all" file.
2. Enhanced Coverage
cmath Module: Added comprehensive unit tests for complex_num, add, sub, mul, and magnitude. Previously, this module had no dedicated test coverage.
Cubic Solver: Added a test case specifically for equations with complex roots in basic_qubic to ensure mathematical correctness.
3. Bug Fixes
simple_equ/algebra/algebra.py: Fixed a TypeError in basic_qubic where the built-in round() function was called directly on complex objects. The logic now correctly rounds the real and imaginary parts independently and gracefully handles roots that simplify to real floats.

Verification Results
All tests in the algebra package were verified using pytest:

Status: Pass