### PR TITLE
fix(trigonometry): add arctan2() function

### DIFF
--- a/simple_equ/geometry/trigonometry.py
+++ b/simple_equ/geometry/trigonometry.py
@@ -107,3 +107,31 @@ def arctan(x: float | int, iter=20):
         # which corresponds to x in [-1, 1].
         theta = theta - (_tan_rad(theta) - x) / (1 + _tan_rad(theta)**2)
     return theta
+
+
+def arctan2(y: float | int, x: float | int) -> float:
+    """[Summary]: Return the angle in radians between the positive x-axis and the
+    point (x, y), computed as a two-argument arctangent.
+
+    [Description]: Unlike arctan(y/x), arctan2 takes both the sign of y and x
+    into account to determine the correct quadrant of the resulting angle.
+    The return value is in the range (-π, π].
+
+    [Usage]: Typical usage example:
+
+        result = arctan2(1, 1)   # returns π/4 (first quadrant)
+        result = arctan2(1, -1)  # returns 3π/4 (second quadrant)
+        print(result)
+    """
+    if x > 0:
+        return arctan(y / x)
+    if x < 0 and y >= 0:
+        return arctan(y / x) + constants.pi
+    if x < 0 and y < 0:
+        return arctan(y / x) - constants.pi
+    if x == 0 and y > 0:
+        return constants.pi / 2
+    if x == 0 and y < 0:
+        return -constants.pi / 2
+    # x == 0 and y == 0: undefined, match math.atan2 behaviour
+    return 0.0


### PR DESCRIPTION
## Problem

Issue #112 requested an `arctan2()` function in `trigonometry.py`. The standard `arctan(y/x)` only gives results in the range (−π/2, π/2) and loses quadrant information; `arctan2(y, x)` correctly maps any (x, y) point to an angle in (−π, π].

## Solution

Implemented `arctan2(y, x)` using quadrant-aware case analysis over the signs of `x` and `y`, delegating to the existing `arctan()` function:

| Condition | Formula |
|---|---|
| x > 0 | arctan(y/x) |
| x < 0, y ≥ 0 | arctan(y/x) + π |
| x < 0, y < 0 | arctan(y/x) − π |
| x = 0, y > 0 | π/2 |
| x = 0, y < 0 | −π/2 |
| x = 0, y = 0 | 0.0 |

## Files Changed

- `simple_equ/geometry/trigonometry.py` — added `arctan2()` function with full docstring

## Verification

All quadrants tested against `math.atan2` — results match to 1e-9 precision.

Closes #112