### PR TITLE
fix(statistics): add probability() function

### DIFF
--- a/simple_equ/economics/statistics.py
+++ b/simple_equ/economics/statistics.py
@@ -97,6 +97,26 @@ def linear_regression(x: list[float] | list[int], y: list[float] | list[int]) ->
     return slope, intercept
 
 
+def probability(favorable_outcomes: int | float, possible_outcomes: int | float) -> float:
+    """[Summary]: Return the probability of an event as a float.
+
+    [Description]: Computes the classical probability by dividing the number of
+    favorable outcomes by the total number of possible outcomes. Raises a
+    ValueError when possible_outcomes is zero or when either argument is
+    negative.
+
+    [Usage]: Typical usage example:
+
+        result = probability(1, 6)   # probability of rolling a 4 on a dice
+        print(result)                # 0.16666...
+    """
+    if possible_outcomes == 0:
+        raise ValueError("possible_outcomes must be greater than zero")
+    if favorable_outcomes < 0 or possible_outcomes < 0:
+        raise ValueError("outcomes must be non-negative")
+    return favorable_outcomes / possible_outcomes
+
+
 def dot(x, w):
     """[Summary]: Return the dot product of two equally sized iterables.
 


### PR DESCRIPTION
## Problem

Issue #105 requested a `probability()` function in `statistics.py` that computes `favorable_outcomes / possible_outcomes` and returns a float approximation — e.g. the probability of rolling a 4 on a die is `probability(1, 6)` → `0.1666...`

## Solution

Added `probability(favorable_outcomes, possible_outcomes)` with:
- Straightforward ratio calculation returning a float
- `ValueError` guard when `possible_outcomes == 0`
- `ValueError` guard when either argument is negative
- Full docstring following the project convention

## Files Changed

- `simple_equ/economics/statistics.py` — added `probability()` function

## Verification

```python
from simple_equ.economics.statistics import probability

probability(1, 6)  # ≈ 0.1667 — rolling a specific side on a die
probability(3, 6)  # 0.5 — rolling an even number
probability(0, 6)  # 0.0
probability(6, 6)  # 1.0
```

Closes #105