### PR TITLE
fix: add bayes theorem function

### DIFF
--- a/simple_equ/economics/statistics.py
+++ b/simple_equ/economics/statistics.py
@@ -129,3 +129,20 @@ def dot(x, w):
         print(result)
     """
     return sum(x_i * w_i for x_i, w_i in zip(x, w))
+
+
+def bayes_theorem(p_b_given_a: float, p_a: float, p_b: float) -> float:
+    """[Summary]: Calculate the posterior probability using Bayes' Theorem.
+
+    [Description]: Computes P(A|B) = (P(B|A) * P(A)) / P(B).
+    Returns the posterior probability of event A given that B has occurred.
+
+    [Usage]: Typical usage example:
+
+        # P(B|A) = 0.9, P(A) = 0.01, P(B) = 0.05
+        result = bayes_theorem(0.9, 0.01, 0.05)
+        print(result) # 0.18
+    """
+    if p_b == 0:
+        raise ValueError("p_b must be greater than zero")
+    return (p_b_given_a * p_a) / p_b

--- a/tests/statistics/test_statistics.py
+++ b/tests/statistics/test_statistics.py
@@ -4,7 +4,7 @@ import sys
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT))
-from simple_equ.economics.statistics import average, median, percentage, linear_regression, dot
+from simple_equ.economics.statistics import average, median, percentage, linear_regression, dot, bayes_theorem
 
 
 # ==============================================================================
@@ -512,3 +512,32 @@ def test_dot_parallel_unit_vectors():
         pytest tests/test_math_utils.py -k test_dot_parallel_unit_vectors
     """
     assert dot([1, 0], [1, 0]) == pytest.approx(1)
+
+
+# ==============================================================================
+# bayes_theorem()
+# ==============================================================================
+
+@pytest.mark.parametrize(
+    "p_b_given_a,p_a,p_b,expected",
+    [
+        (0.9, 0.01, 0.05, 0.18),
+        (0.8, 0.5, 0.4, 1.0),
+        (0.1, 0.1, 0.01, 1.0),
+        (0.5, 0.2, 0.5, 0.2),
+    ],
+)
+def test_bayes_theorem_numeric(p_b_given_a, p_a, p_b, expected):
+    """[Summary]: Verify that bayes_theorem returns the correct posterior probability.
+
+    [Description]: Runs parametrized inputs covering various probability
+    scenarios, comparing results against known expected values.
+    """
+    assert bayes_theorem(p_b_given_a, p_a, p_b) == pytest.approx(expected)
+
+
+def test_bayes_theorem_zero_p_b():
+    """[Summary]: Verify that bayes_theorem raises when p_b is zero.
+    """
+    with pytest.raises(ValueError, match="p_b must be greater than zero"):
+        bayes_theorem(0.9, 0.01, 0)


### PR DESCRIPTION
This PR adds the `bayes_theorem` function to `simple_equ/economics/statistics.py` and corresponding tests.

### Changes:
- Added `bayes_theorem` function to calculate posterior probability.
- Added unit tests for `bayes_theorem` in `tests/statistics/test_statistics.py`.

Fixes #106