### PR TITLE
Feature | Add distance conversion functionality 

### DIFF
--- a/simple_equ/physics/constants.py
+++ b/simple_equ/physics/constants.py
@@ -1,0 +1,31 @@
+# Physics constants for unit conversions
+
+# Conversion factors (base unit: meters)
+METERS_TO_FEET = 3.280839895
+METERS_TO_INCHES = 39.3700787
+
+# Unit aliases for common abbreviations
+UNIT_ALIASES = {
+    'm': 'meters',
+    'meter': 'meters',
+    'ft': 'feet',
+    'foot': 'feet',
+    'in': 'inches',
+    'inch': 'inches',
+}
+
+# Conversion factors dictionary (from: {to: factor})
+CONVERSION_FACTORS = {
+    'meters': {
+        'feet': METERS_TO_FEET,
+        'inches': METERS_TO_INCHES,
+    },
+    'feet': {
+        'meters': 1 / METERS_TO_FEET,
+        'inches': 12,  # 1 foot = 12 inches
+    },
+    'inches': {
+        'meters': 1 / METERS_TO_INCHES,
+        'feet': 1 / 12,
+    },
+}

--- a/simple_equ/physics/units.py
+++ b/simple_equ/physics/units.py
@@ -1,1 +1,45 @@
 #This file will be used for unit conversions
+
+from . import constants
+
+
+def distance_converter(value, from_unit: str, to_unit: str):
+    """[Summary]: Convert distance between supported units.
+
+    [Description]: Converts a distance value from one unit to another using
+    predefined conversion factors. Supports meters, feet, and inches with
+    common abbreviations. Returns the value unchanged if units are the same.
+    Raises ValueError for invalid units or negative values.
+
+    [Usage]: Typical usage example:
+
+        result = distance_converter(10, 'meters', 'feet')
+        print(result)  # Output: 32.80839895
+    """
+    # Input validation
+    if not isinstance(value, (int, float)):
+        raise TypeError("Value must be a number (int or float).")
+    if value < 0:
+        raise ValueError("Distance cannot be negative.")
+
+    # Normalize units using aliases
+    from_unit_normalized = constants.UNIT_ALIASES.get(from_unit.lower(), from_unit.lower())
+    to_unit_normalized = constants.UNIT_ALIASES.get(to_unit.lower(), to_unit.lower())
+
+    # Check for same units first
+    if from_unit_normalized == to_unit_normalized:
+        return value
+
+    # Check if units are supported
+    if from_unit_normalized not in constants.CONVERSION_FACTORS:
+        raise ValueError(f"Unsupported 'from' unit: '{from_unit}'. "
+                         f"Supported units: {list(constants.CONVERSION_FACTORS.keys())}")
+    if to_unit_normalized not in constants.CONVERSION_FACTORS[from_unit_normalized]:
+        raise ValueError(f"Unsupported conversion from '{from_unit}' to '{to_unit}'. "
+                         f"Supported conversions from {from_unit_normalized}: "
+                         f"{list(constants.CONVERSION_FACTORS[from_unit_normalized].keys())}")
+
+    # Perform conversion
+    factor = constants.CONVERSION_FACTORS[from_unit_normalized][to_unit_normalized]
+    return value * factor
+    


### PR DESCRIPTION
## Description
This PR introduces a new distance_converter function in the physics module to handle unit conversions for distances. The implementation supports conversions between meters, feet, and inches, with support for common unit abbreviations.

## Related Issues
Issue #121 

## Changes Made
* Added `constants.py`in physics):
* Defined precise conversion factors (e.g., `METERS_TO_FEET= 3.280839895`).
* Created `UNIT_ALIASES` dictionary for common abbreviations ('m' → 'meters', 'ft' → 'feet', 'in' → 'inches').
* Implemented `CONVERSION_FACTORS` dictionary for extensible unit conversions.

* Added distance_converter(value, from_unit, to_unit) function.
* Includes input validation (type checking, non-negative values).
* Supports unit normalization and aliases.
* Handles same-unit conversions and provides clear error messages for unsupported units.

## Note

I added inches as an option to convert and added a constants.py.
If you don't like it, let me know and I'll change it.