### PR TITLE
feat: add polygon area helper

### DIFF
--- a/simple_equ/geometry/two_dimensional.py
+++ b/simple_equ/geometry/two_dimensional.py
@@ -87,6 +87,20 @@ def triangle_area(base: int | float, height: int | float):
     return (base * height) / 2
 
 
+def regular_polygon_area(apothem: int | float, perimeter: int | float):
+    """[Summary]: Return the area of a regular polygon.
+
+    [Description]: Multiplies the apothem by the perimeter and divides the
+    result by two to compute the area of a regular polygon.
+
+    [Usage]: Typical usage example:
+
+        result = regular_polygon_area(4, 20)
+        print(result)
+    """
+    return (apothem * perimeter) / 2
+
+
 def calculate_radius(diameter: int | float):
     """[Summary]: Return the radius derived from a diameter.
 

--- a/tests/geometry/test_geometry.py
+++ b/tests/geometry/test_geometry.py
@@ -168,6 +168,28 @@ def test_triangle_area(base, h, expected):
 
 
 @pytest.mark.parametrize(
+    "apothem,perimeter,expected",
+    [
+        (4, 20, 40.0),
+        (3.5, 12, 21.0),
+        (7, 8.5, 29.75),
+        (0, 10, 0.0),
+    ],
+)
+def test_regular_polygon_area(apothem, perimeter, expected):
+    """[Summary]: Verify that regular_polygon_area returns the expected area.
+
+    [Description]: Exercises the regular polygon area helper with integer,
+    floating-point, and zero-value inputs.
+
+    [Usage]: Typical usage example:
+
+        pytest tests/geometry/test_geometry.py -k test_regular_polygon_area
+    """
+    assert geo.regular_polygon_area(apothem, perimeter) == pytest.approx(expected, rel=1e-9)
+
+
+@pytest.mark.parametrize(
     "l,w,h,expected",
     [
         (1, 1, 1, pytest.approx(3.236, rel=1e-3)),


### PR DESCRIPTION
Added the polygon area helper and verified it with targeted tests.

I also ran the full geometry test file. The remaining failures appear to be unrelated pre-existing issues in the inverse trig helpers (`arcsin` / `arccos`), not caused by this change.

Closes #124
